### PR TITLE
feat: support spatie/laravel-query-builder ^7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "kirschbaum-development/eloquent-power-joins": "^4.0",
         "spatie/invade": "^2.1",
         "spatie/laravel-package-tools": "^1.14.0",
-        "spatie/laravel-query-builder": "^6.0"
+        "spatie/laravel-query-builder": "^6.0|^7.0"
     },
     "require-dev": {
         "knuckleswtf/scribe": "^5.0",

--- a/tests/Filters/DateFilterTest.php
+++ b/tests/Filters/DateFilterTest.php
@@ -85,7 +85,7 @@ it('does not apply the filter when value is not an array of dates', function () 
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('created_at', new DateFilter),
         ]);
 
@@ -106,7 +106,7 @@ it('does not apply the filter if the value is not a date or null', function () {
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('created_at', new DateFilter),
         ]);
 
@@ -124,7 +124,7 @@ it('apply filter without sub levels (value, operator)', function () {
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('created_at', new DateFilter),
         ]);
 
@@ -144,7 +144,7 @@ it('apply filter without sub levels (operator)', function () {
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('created_at', new DateFilter),
         ]);
 
@@ -164,7 +164,7 @@ it('apply filter without sub levels (value)', function () {
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('created_at', new DateFilter),
         ]);
 
@@ -188,7 +188,7 @@ it('apply filter with multi levels (value)', function () {
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('created_at', new DateFilter),
         ]);
 
@@ -209,7 +209,7 @@ it('filters using all date comparison operators', function ($value, $operator, $
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('created_at', new DateFilter),
         ]);
 
@@ -242,7 +242,7 @@ it('apply filter on relationships of type "belongsTo"', function () {
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('author.created_at', new DateFilter),
         ]);
 
@@ -263,7 +263,7 @@ it('apply filter on relationships of type "hasMany"', function () {
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('chapters.created_at', new DateFilter),
         ]);
 
@@ -284,7 +284,7 @@ it('apply filter on relationships using joins', function () {
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::query()->joinRelationship('author'), $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('authors.created_at', new DateFilter(false)),
         ]);
 
@@ -309,7 +309,7 @@ it('apply filter on relationships using dynamic power joins', function () {
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('author.created_at', new DateFilter(false, JoinType::Inner)),
             AllowedFilter::custom('author.country.created_at', new DateFilter(false, JoinType::Inner)),
         ]);
@@ -331,7 +331,7 @@ it('filters using all number comparison operators with power joins', function ($
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('author.created_at', new DateFilter(false, JoinType::Inner)),
         ]);
 

--- a/tests/Filters/GlobalFilterTest.php
+++ b/tests/Filters/GlobalFilterTest.php
@@ -57,7 +57,7 @@ it('the query is formed correctly', function () {
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             GlobalFilter::allowed([
                 'author.name',
                 'title',
@@ -86,7 +86,7 @@ it('does not apply the filter if the value is not a string', function () {
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             GlobalFilter::allowed([
                 'author.name',
                 'title',
@@ -107,7 +107,7 @@ it('apply filter on properties model', function ($value, $expected, $count) {
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             GlobalFilter::allowed([
                 'title',
                 'isbn',
@@ -135,7 +135,7 @@ it('apply filter on query expression', function ($value, $expected, $count) {
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             GlobalFilter::allowed([
                 new Expression("CONCAT(books.title, ' - ', books.isbn)"),
             ]),
@@ -162,7 +162,7 @@ it('apply filter on relationships of type "belongsTo"', function ($value, $expec
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             GlobalFilter::allowed(['author.name', 'author.email']),
         ]);
 
@@ -187,7 +187,7 @@ it('apply filter on relationships of type "belongsTo" (deep)', function ($value,
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             GlobalFilter::allowed(['author.country.name', 'author.country.code']),
         ]);
 
@@ -212,7 +212,7 @@ it('apply filter on relationships of type "hasMany"', function ($value, $expecte
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::query()->with(['author']), $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             GlobalFilter::allowed(['chapters.title', 'chapters.number']),
         ]);
 
@@ -241,7 +241,7 @@ it('apply filter on properties and relationships using joins', function ($value,
         ->join('countries', 'countries.id', 'authors.country_id');
 
     $queryBuilder = QueryBuilder::for($query, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             GlobalFilter::allowed(['title', 'isbn', 'countries.name', 'authors.name'], false),
         ]);
 
@@ -262,7 +262,7 @@ it('apply filter on properties and relationships using dynamic power joins', fun
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             GlobalFilter::allowed(['title', 'isbn', 'author.name', 'author.country.name'], false, JoinType::Inner),
         ]);
 
@@ -283,7 +283,7 @@ it('filter by all properties', function () {
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             GlobalFilter::allowed([
                 'author.name',
                 'title',

--- a/tests/Filters/HasRelationshipFilterTest.php
+++ b/tests/Filters/HasRelationshipFilterTest.php
@@ -71,7 +71,7 @@ it('does not apply the filter if the value is invalid', function () {
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('has_chapters', new HasRelationshipFilter, 'chapters'),
         ]);
 
@@ -89,7 +89,7 @@ it('applies the "has relationship" filter when the provided value is "1"', funct
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('has_chapters', new HasRelationshipFilter, 'chapters'),
         ]);
 
@@ -107,7 +107,7 @@ it('applies the "doesnt have relationship" filter when the provided value is "0"
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('has_chapters', new HasRelationshipFilter, 'chapters'),
         ]);
 

--- a/tests/Filters/NumberFilterTest.php
+++ b/tests/Filters/NumberFilterTest.php
@@ -85,7 +85,7 @@ it('does not apply the filter when value is not an array of numbers', function (
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('order', new NumberFilter),
         ]);
 
@@ -106,7 +106,7 @@ it('does not apply the filter if the value is not a numeric or null', function (
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('order', new NumberFilter),
         ]);
 
@@ -124,7 +124,7 @@ it('apply filter without sub levels (value, operator)', function () {
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('order', new NumberFilter),
         ]);
 
@@ -144,7 +144,7 @@ it('apply filter without sub levels (operator)', function () {
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('order', new NumberFilter),
         ]);
 
@@ -164,7 +164,7 @@ it('apply filter without sub levels (value)', function () {
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('order', new NumberFilter),
         ]);
 
@@ -188,7 +188,7 @@ it('apply filter with multi levels (value)', function () {
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('order', new NumberFilter),
         ]);
 
@@ -209,7 +209,7 @@ it('filters using all number comparison operators', function ($value, $operator,
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('order', new NumberFilter),
         ]);
 
@@ -242,7 +242,7 @@ it('apply filter on relationships of type "belongsTo"', function () {
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('author.order', new NumberFilter),
         ]);
 
@@ -263,7 +263,7 @@ it('apply filter on relationships of type "hasMany"', function () {
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('chapters.order', new NumberFilter),
         ]);
 
@@ -284,7 +284,7 @@ it('apply filter on relationships using joins', function () {
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::query()->joinRelationship('author'), $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('authors.order', new NumberFilter(false)),
         ]);
 
@@ -309,7 +309,7 @@ it('apply filter on relationships using dynamic power joins', function () {
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('author.order', new NumberFilter(false, JoinType::Inner)),
             AllowedFilter::custom('author.country.order', new NumberFilter(false, JoinType::Inner)),
         ]);
@@ -331,7 +331,7 @@ it('filters using all number comparison operators with power joins', function ($
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('author.order', new NumberFilter(false, JoinType::Inner)),
         ]);
 

--- a/tests/Filters/PowerJoins/TextFilterTest.php
+++ b/tests/Filters/PowerJoins/TextFilterTest.php
@@ -46,7 +46,7 @@ it('apply relationships using aliases that point to the same table', function ()
     ]);
 
     $queryBuilder = QueryBuilder::for(Flight::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('departure.name', new TextFilter(false, JoinType::Inner, 'departure')),
             AllowedFilter::custom('arrival.name', new TextFilter(false, JoinType::Inner, 'arrival')),
         ]);

--- a/tests/Filters/TextFilterTest.php
+++ b/tests/Filters/TextFilterTest.php
@@ -84,7 +84,7 @@ it('does not apply the filter if the value is an array of empty strings', functi
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('isbn', new TextFilter),
         ]);
 
@@ -105,7 +105,7 @@ it('does not apply the filter if the value is not a string or null', function ()
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('isbn', new TextFilter),
         ]);
 
@@ -123,7 +123,7 @@ it('apply filter without sub levels (value, operator)', function () {
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('isbn', new TextFilter),
         ]);
 
@@ -143,7 +143,7 @@ it('apply filter without sub levels (operator)', function () {
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('isbn', new TextFilter),
         ]);
 
@@ -163,7 +163,7 @@ it('apply filter without sub levels (value)', function () {
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('isbn', new TextFilter),
         ]);
 
@@ -186,7 +186,7 @@ it('apply filter with multi levels (value)', function () {
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('isbn', new TextFilter),
         ]);
 
@@ -207,7 +207,7 @@ it('filters using all text comparison operators', function ($value, $operator, $
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('isbn', new TextFilter),
         ]);
 
@@ -242,7 +242,7 @@ it('apply filter on relationships of type "belongsTo"', function () {
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('author.email', new TextFilter),
         ]);
 
@@ -263,7 +263,7 @@ it('apply filter on relationships of type "hasMany"', function () {
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('chapters.title', new TextFilter),
         ]);
 
@@ -284,7 +284,7 @@ it('apply filter on relationships using joins', function () {
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::query()->joinRelationship('author'), $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('authors.email', new TextFilter(false)),
         ]);
 
@@ -309,7 +309,7 @@ it('apply filter on relationships using dynamic power joins', function () {
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('author.email', new TextFilter(false, JoinType::Inner)),
             AllowedFilter::custom('author.country.name', new TextFilter(false, JoinType::Inner)),
         ]);
@@ -331,7 +331,7 @@ it('filters using all text comparison operators with power joins', function ($va
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('author.email', new TextFilter(false, JoinType::Inner)),
         ]);
 

--- a/tests/Mongo/Filters/DateFilterTest.php
+++ b/tests/Mongo/Filters/DateFilterTest.php
@@ -58,7 +58,7 @@ it('does not apply the filter when value is not an array of dates', function () 
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('created_at', new DateFilter),
         ]);
 
@@ -76,7 +76,7 @@ it('does not apply the filter if the value is not a date or null', function () {
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('created_at', new DateFilter),
         ]);
 
@@ -91,7 +91,7 @@ it('applies filter without sub levels (value, operator)', function () {
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('created_at', new DateFilter),
         ]);
 
@@ -110,7 +110,7 @@ it('applies filter without sub levels (operator)', function () {
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('created_at', new DateFilter),
         ]);
 
@@ -129,7 +129,7 @@ it('applies filter without sub levels (value)', function () {
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('created_at', new DateFilter),
         ]);
 
@@ -147,7 +147,7 @@ it('filters using all date comparison operators', function ($value, $operator, $
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('created_at', new DateFilter),
         ]);
 
@@ -180,7 +180,7 @@ it('applies filter on relationships of type "belongsTo"', function () {
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('author.created_at', new DateFilter),
         ]);
 
@@ -200,7 +200,7 @@ it('applies filter on relationships of type "hasMany"', function () {
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('chapters.created_at', new DateFilter),
         ]);
 

--- a/tests/Mongo/Filters/GlobalFilterTest.php
+++ b/tests/Mongo/Filters/GlobalFilterTest.php
@@ -55,7 +55,7 @@ it('does not apply the filter if the value is not a string', function () {
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             GlobalFilter::allowed([
                 'author.name',
                 'title',
@@ -73,7 +73,7 @@ it('applies filter on properties model', function ($value, $expected, $count) {
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             GlobalFilter::allowed(['title', 'isbn']),
         ]);
 
@@ -94,7 +94,7 @@ it('applies filter on relationships of type "belongsTo"', function ($value, $exp
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             GlobalFilter::allowed(['author.name', 'author.email']),
         ]);
 
@@ -115,7 +115,7 @@ it('applies filter on relationships of type "belongsTo" (deep)', function ($valu
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             GlobalFilter::allowed(['author.country.name', 'author.country.code']),
         ]);
 
@@ -136,7 +136,7 @@ it('applies filter on relationships of type "hasMany"', function ($value, $expec
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             GlobalFilter::allowed(['chapters.title']),
         ]);
 
@@ -156,7 +156,7 @@ it('filters by all properties and relationships at once', function () {
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             GlobalFilter::allowed([
                 'author.name',
                 'title',

--- a/tests/Mongo/Filters/HasRelationshipFilterTest.php
+++ b/tests/Mongo/Filters/HasRelationshipFilterTest.php
@@ -42,7 +42,7 @@ it('does not apply the filter if the value is invalid', function () {
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('has_chapters', new HasRelationshipFilter, 'chapters'),
         ]);
 
@@ -57,7 +57,7 @@ it('applies the "has relationship" filter when the provided value is "1"', funct
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('has_chapters', new HasRelationshipFilter, 'chapters'),
         ]);
 
@@ -74,7 +74,7 @@ it('applies the "doesnt have relationship" filter when the provided value is "0"
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('has_chapters', new HasRelationshipFilter, 'chapters'),
         ]);
 

--- a/tests/Mongo/Filters/NumberFilterTest.php
+++ b/tests/Mongo/Filters/NumberFilterTest.php
@@ -58,7 +58,7 @@ it('does not apply the filter when value is not an array of numbers', function (
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('order', new NumberFilter),
         ]);
 
@@ -76,7 +76,7 @@ it('does not apply the filter if the value is not numeric or null', function () 
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('order', new NumberFilter),
         ]);
 
@@ -91,7 +91,7 @@ it('applies filter without sub levels (value, operator)', function () {
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('order', new NumberFilter),
         ]);
 
@@ -110,7 +110,7 @@ it('applies filter without sub levels (operator)', function () {
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('order', new NumberFilter),
         ]);
 
@@ -129,7 +129,7 @@ it('applies filter without sub levels (value)', function () {
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('order', new NumberFilter),
         ]);
 
@@ -147,7 +147,7 @@ it('applies filter with multi levels (value)', function () {
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('order', new NumberFilter),
         ]);
 
@@ -165,7 +165,7 @@ it('filters using all number comparison operators', function ($value, $operator,
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('order', new NumberFilter),
         ]);
 
@@ -198,7 +198,7 @@ it('applies filter on relationships of type "belongsTo"', function () {
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('author.order', new NumberFilter),
         ]);
 
@@ -218,7 +218,7 @@ it('applies filter on relationships of type "hasMany"', function () {
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('chapters.order', new NumberFilter),
         ]);
 
@@ -238,7 +238,7 @@ it('filters using all number comparison operators across a relationship', functi
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('author.order', new NumberFilter),
         ]);
 

--- a/tests/Mongo/Filters/TextFilterTest.php
+++ b/tests/Mongo/Filters/TextFilterTest.php
@@ -58,7 +58,7 @@ it('does not apply the filter if the value is an array of empty strings', functi
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('isbn', new TextFilter),
         ]);
 
@@ -76,7 +76,7 @@ it('does not apply the filter if the value is not a string or null', function ()
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('isbn', new TextFilter),
         ]);
 
@@ -91,7 +91,7 @@ it('applies filter without sub levels (value, operator)', function () {
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('isbn', new TextFilter),
         ]);
 
@@ -110,7 +110,7 @@ it('applies filter without sub levels (operator)', function () {
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('isbn', new TextFilter),
         ]);
 
@@ -129,7 +129,7 @@ it('applies filter without sub levels (value)', function () {
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('isbn', new TextFilter),
         ]);
 
@@ -147,7 +147,7 @@ it('applies filter with multi levels (value)', function () {
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('isbn', new TextFilter),
         ]);
 
@@ -165,7 +165,7 @@ it('filters using all text comparison operators', function ($value, $operator, $
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('isbn', new TextFilter),
         ]);
 
@@ -200,7 +200,7 @@ it('applies filter on relationships of type "belongsTo"', function () {
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('author.email', new TextFilter),
         ]);
 
@@ -220,7 +220,7 @@ it('applies filter on relationships of type "hasMany"', function () {
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('chapters.title', new TextFilter),
         ]);
 
@@ -238,7 +238,7 @@ it('filters using all text comparison operators across a relationship', function
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::custom('author.email', new TextFilter),
         ]);
 

--- a/tests/Queries/PerPageQueryBuilderTest.php
+++ b/tests/Queries/PerPageQueryBuilderTest.php
@@ -107,16 +107,16 @@ it('returns the links with the URL parameters provided', function () {
     ]);
 
     $queryBuilder = QueryBuilder::for(Author::class, $this->request)
-        ->allowedFilters([
+        ->allowedFilters(...[
             AllowedFilter::exact('country_id'),
             AllowedFilter::partial('name'),
             AllowedFilter::partial('email'),
         ])
-        ->allowedSorts([
+        ->allowedSorts(...[
             AllowedSort::field('order'),
             AllowedSort::field('created_at'),
         ])
-        ->allowedIncludes([
+        ->allowedIncludes(...[
             AllowedInclude::relationship('country'),
             AllowedInclude::relationship('books'),
         ]);

--- a/tests/Sorts/CaseSortTest.php
+++ b/tests/Sorts/CaseSortTest.php
@@ -56,7 +56,7 @@ it('sorts the records in ascending order', function () {
         ->toArray();
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedSorts([
+        ->allowedSorts(...[
             AllowedSort::custom('classification', new CaseSort($cases)),
         ]);
 
@@ -81,7 +81,7 @@ it('sorts the records in descending order', function () {
         ->toArray();
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedSorts([
+        ->allowedSorts(...[
             AllowedSort::custom('classification', new CaseSort($cases)),
         ]);
 
@@ -106,7 +106,7 @@ it('sort records by relationship fields', function () {
         ->toArray();
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedSorts([
+        ->allowedSorts(...[
             AllowedSort::custom('author.type', new CaseSort($cases)),
         ]);
 

--- a/tests/Sorts/PowerJoins/RelationSortTest.php
+++ b/tests/Sorts/PowerJoins/RelationSortTest.php
@@ -36,7 +36,7 @@ it('apply relationships using aliases that point to the same table', function ()
     ]);
 
     $queryBuilder = QueryBuilder::for(Flight::class, $this->request)
-        ->allowedSorts([
+        ->allowedSorts(...[
             AllowedSort::custom('departure.code', new RelationSort(JoinType::Inner, joinAliases: 'departure')),
             AllowedSort::custom('arrival.code', new RelationSort(JoinType::Inner, joinAliases: 'arrival')),
         ]);

--- a/tests/Sorts/RelationSortTest.php
+++ b/tests/Sorts/RelationSortTest.php
@@ -61,7 +61,7 @@ it('sort the records in ascending order using the "BelongTo" relationship', func
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedSorts([
+        ->allowedSorts(...[
             AllowedSort::custom('author.name', new RelationSort(JoinType::Inner)),
         ]);
 
@@ -78,7 +78,7 @@ it('sort the records in descending order using the "BelongTo" relationship', fun
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedSorts([
+        ->allowedSorts(...[
             AllowedSort::custom('author.name', new RelationSort(JoinType::Inner)),
         ]);
 
@@ -95,7 +95,7 @@ it('sort the records in ascending order using the "BelongTo" relationship (deep 
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedSorts([
+        ->allowedSorts(...[
             AllowedSort::custom('author.country.name', new RelationSort(JoinType::Inner)),
         ]);
 
@@ -112,7 +112,7 @@ it('sort the records in descending order using the "BelongTo" relationship (deep
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedSorts([
+        ->allowedSorts(...[
             AllowedSort::custom('author.country.name', new RelationSort(JoinType::Inner)),
         ]);
 
@@ -129,7 +129,7 @@ it('sort the records in ascending order using the "HasMany" relationship with ag
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedSorts([
+        ->allowedSorts(...[
             AllowedSort::custom('chapters.number', new RelationSort(JoinType::Left, AggregationType::Sum)),
         ]);
 
@@ -146,7 +146,7 @@ it('sort the records in descending order using the "HasMany" relationship with a
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedSorts([
+        ->allowedSorts(...[
             AllowedSort::custom('chapters.number', new RelationSort(JoinType::Left, AggregationType::Sum)),
         ]);
 
@@ -163,7 +163,7 @@ it('sort the records in descending order using the "HasMany" relationship with a
     ]);
 
     $queryBuilder = QueryBuilder::for(Book::class, $this->request)
-        ->allowedSorts([
+        ->allowedSorts(...[
             AllowedSort::custom('chapters.number',
                 new RelationSort(JoinType::Left, AggregationType::Sum, 'chapters_alias')
             ),
@@ -184,7 +184,7 @@ it('sort the records in descending order using the multiple relationship aliases
     ]);
 
     $queryBuilder = QueryBuilder::for(Country::class, $this->request)
-        ->allowedSorts([
+        ->allowedSorts(...[
             AllowedSort::custom('authors.books.order',
                 new RelationSort(JoinType::Inner, joinAliases: [
                     'authors' => fn ($join) => $join->as('authors_alias'),


### PR DESCRIPTION
## Contexto
El paquete fija `spatie/laravel-query-builder: ^6.0`, lo que impide instalarlo en proyectos que ya usan **^7** (el backend RUDY V2 lo necesita — `composer require` falla la resolución).

## Cambio
- **composer.json**: constraint ampliado a `^6.0|^7.0` (sigue soportando v6).
- **src/ (producción)**: sin cambios. El único breaking change de v7 que toca al paquete es que las interfaces `Filter`/`Sort` exigen `__invoke(): void` — y el paquete **ya lo declara** así.
- **tests**: las allow-lists (`allowedFilters/allowedSorts/allowedIncludes`) pasan por el operador spread (`allowedFilters(...[...])`), compatible con v6 **y** v7 (en v7 son variádicas y ya no aceptan un array).

## Validación
- `php -l` OK en todos los tests modificados · `pint` limpio.
- La suite completa la valida el **CI del repo** (tiene el servicio MySQL `mysql` que el `phpunit.xml` espera; localmente sin ese host no corre).

> Nota (opcional): el spread `...[]` es el cambio mínimo; si prefieres variádico "limpio" (quitar los corchetes) lo ajusto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)